### PR TITLE
removed extra case in equals method

### DIFF
--- a/src/LinkedQueue.java
+++ b/src/LinkedQueue.java
@@ -129,8 +129,6 @@ public class LinkedQueue<E> implements Iterable<E> {
     public boolean equals(LinkedQueue other) {
         if (this.size() != other.size()) {
             return false;
-        } else if (this.isEmpty() && other.isEmpty()) {
-            return true;
         } else {
             QueueNode current1 = this.front;
             QueueNode current2 = other.front;


### PR DESCRIPTION
The else if check is not needed because the empty lists case is handled by the else case
